### PR TITLE
fix: resolve React Hooks rules violations for Vercel deployment

### DIFF
--- a/src/components/DraggableWindow.tsx
+++ b/src/components/DraggableWindow.tsx
@@ -30,10 +30,6 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
   const [startPosition, setStartPosition] = useState({ x: 0, y: 0 });
   const windowRef = useRef<HTMLDivElement>(null);
 
-  if (!window.isVisible) {
-    return null;
-  }
-
   const handleMouseDown = (e: React.MouseEvent) => {
     if (e.target !== e.currentTarget && !isHeaderElement(e.target as Element)) {
       return;
@@ -114,7 +110,11 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
       document.removeEventListener('touchmove', handleTouchMove);
       document.removeEventListener('touchend', handleEnd);
     };
-  }, [isDragging, dragStart, startPosition, window.id, window.position.width, window.position.height, onPositionChange]);
+  }, [isDragging, dragStart, startPosition, window.id, window.position.width, window.position.height, onPositionChange, zoom]);
+
+  if (!window.isVisible) {
+    return null;
+  }
 
   return (
     <div

--- a/src/components/FloatingWindow.tsx
+++ b/src/components/FloatingWindow.tsx
@@ -23,23 +23,7 @@ export const FloatingWindow: React.FC<FloatingWindowProps> = ({
   highlightedMethod,
   onMethodClick
 }) => {
-  if (!window.isVisible) {
-    return null;
-  }
-
   const { id, file, position, isCollapsed, showMethodsOnly } = window;
-
-  const handleToggleCollapse = () => {
-    onToggleCollapse(id);
-  };
-
-  const handleToggleMethodsOnly = () => {
-    onToggleMethodsOnly(id);
-  };
-
-  const handleClose = () => {
-    onClose(id);
-  };
 
   const [highlightedCode, setHighlightedCode] = useState<string>('');
   const processedContentRef = useRef<string>('');
@@ -53,6 +37,18 @@ export const FloatingWindow: React.FC<FloatingWindowProps> = ({
   
   // ホイールスクロール分離フックを使用
   const { handleWheel } = useWheelScrollIsolation(contentRef);
+
+  const handleToggleCollapse = () => {
+    onToggleCollapse(id);
+  };
+
+  const handleToggleMethodsOnly = () => {
+    onToggleMethodsOnly(id);
+  };
+
+  const handleClose = () => {
+    onClose(id);
+  };
 
   // Refを常に最新の値に更新
   useEffect(() => {
@@ -255,7 +251,7 @@ export const FloatingWindow: React.FC<FloatingWindowProps> = ({
       processedContentRef.current = currentContentKey;
       highlightCode();
     }
-  }, [file.content, isCollapsed, showMethodsOnly, file.language]);
+  }, [file.content, isCollapsed, showMethodsOnly, file.language, file.methods]);
 
   // コンテンツ変更後にスクロール情報を更新
   useEffect(() => {
@@ -382,6 +378,11 @@ export const FloatingWindow: React.FC<FloatingWindowProps> = ({
       }
     }
   }, [highlightedMethod, file.path, isCollapsed, showMethodsOnly, id]);
+
+  // 非表示の場合は早期リターン
+  if (!window.isVisible) {
+    return null;
+  }
 
   const renderContent = () => {
     if (isCollapsed) {


### PR DESCRIPTION
  fix: resolve React Hooks violations for Vercel deployment

  本文

  ## Summary
  🔧 **Critical Fix**: Resolve React Hooks rules violations that prevented Vercel deployment

  ### Key Changes
  - **FloatingWindow.tsx**: Move all Hook calls before conditional returns
  - **DraggableWindow.tsx**: Fix conditional Hook execution and add missing dependencies
  - **Build Success**: Eliminate all React Hooks ESLint errors while preserving functionality

  ### Problem Solved
  ❌ **Before**: Conditional Hook calls causing build failures
  ✅ **After**: Proper Hook execution order + successful production build

  ## Issues Fixed
  - **React Hook "useState" is called conditionally** → Moved all Hooks to component top
  - **React Hook "useEffect" is called conditionally** → Placed early returns after all Hooks
  - **Missing dependency 'zoom' in useEffect** → Added to dependency array
  - **Missing dependency 'file.methods'** → Added to prevent stale closures

  ## Technical Details

  ### Root Cause
  ```typescript
  // ❌ BEFORE: Hooks called after conditional return
  if (!window.isVisible) return null;
  const [state] = useState(); // Conditional execution!

  // ✅ AFTER: All Hooks first, then conditional logic
  const [state] = useState(); // Always executed
  if (!window.isVisible) return null;

  Dependency Array Corrections

  - Added file.methods to prevent stale method references
  - Added zoom parameter to fix drag scaling calculations
  - Preserved original functionality while fixing violations

  Test Results

  - ✅ Build: npm run build succeeds without errors
  - ✅ Dev Mode: npm run dev works normally
  - ✅ Functionality: All features preserved (drag, scroll, method clicks)
  - ✅ Performance: No infinite rendering loops

  Deployment Ready

  🚀 Status: Ready for Vercel deployment
  - All React Hooks violations resolved
  - Production build successful
  - No breaking changes to user functionality

  Previous Attempt

  ⚠️  First attempt caused infinite rendering by incorrectly adding window object to dependency arrays. This fix uses proper selective dependencies and
  maintains stable references.

  🤖 Generated with https://claude.ai/code
