### PR TITLE
fix: use production domain instead of preview URL for OGP

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,7 +4,7 @@ import '../styles/prism-theme.css'
 import { FilesProvider } from '@/context/FilesContext'
 
 const baseUrl = process.env.NODE_ENV === 'production' 
-  ? (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : 'https://flow-code-links.vercel.app')
+  ? 'https://flow-code-links.vercel.app'
   : 'http://localhost:3001';
 
 const TITLE = 'FlowCodeLinks';


### PR DESCRIPTION
- Replace dynamic VERCEL_URL with hardcoded production domain
- Ensures OGP images use correct https://flow-code-links.vercel.app URL
- Fixes social sharing preview issues caused by preview URL mismatch

🤖 Generated with [Claude Code](https://claude.ai/code)