### PR TITLE
fix: use absolute URLs for OGP images with environment-based switching

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,8 +11,29 @@ const TITLE = 'FlowCodeLinks';
 const DESCRIPTION = 'Visualize code flow and method relationships';
 
 export const metadata: Metadata = {
-  title: 'FlowCodeLinks',
-  description: 'Visualize code flow and method relationships',
+  title: TITLE,
+  description: DESCRIPTION,
+  openGraph: {
+    title: TITLE,
+    description: DESCRIPTION,
+    siteName: TITLE,
+    images: [
+      {
+        url: `${baseUrl}/ogp.png`,
+        width: 1200,
+        height: 630,
+        alt: 'FlowCodeLinks - Visualize code flow and method relationships',
+      },
+    ],
+    locale: 'ja_JP',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: TITLE,
+    description: DESCRIPTION,
+    images: [`${baseUrl}/ogp.png`],
+  },
 }
 
 export default function RootLayout({
@@ -24,14 +45,6 @@ export default function RootLayout({
     <html lang="ja" data-theme="nord">
       <head>
         <link rel="icon" href="/favicon.png" />
-        <meta property="og:title" content="FlowCodeLinks" />
-        <meta property="og:description" content="Visualize code flow and method relationships" />
-        <meta property="og:image" content="/ogp.png" />
-        <meta property="og:type" content="website" />
-        <meta name="twitter:card" content="summary_large_image" />
-        <meta name="twitter:title" content="FlowCodeLinks" />
-        <meta name="twitter:description" content="Visualize code flow and method relationships" />
-        <meta name="twitter:image" content="/ogp.png" />
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="" />
         <link href="https://fonts.googleapis.com/css2?family=Raleway:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet" />


### PR DESCRIPTION
- Add baseUrl that switches between production and development environments
- Use absolute URLs for OGP and Twitter images
- Production: https://flow-code-links.vercel.app
- Development: http://localhost:3001
- Ensures OGP images work correctly in both environments

🤖 Generated with [Claude Code](https://claude.ai/code)